### PR TITLE
Weaken tagsoup bound

### DIFF
--- a/country-codes.cabal
+++ b/country-codes.cabal
@@ -41,7 +41,7 @@ executable country-codes-generate
   build-depends:
       base                 >= 4    && < 5
     , text                 >= 0.11
-    , tagsoup              >= 0.13 && < 0.14
+    , tagsoup              >= 0.13 && < 0.15
   ghc-options:     -Wall -rtsopts
   main-is:         Main.hs
   if !flag(generate)


### PR DESCRIPTION
This makes it buildable against Stackage Nightly. Tests pass and running `country-codes-generate` gives identical output. You can update the cabal file without uploading a new version at http://hackage.haskell.org/package/country-codes/maintain.
