### PR TITLE
Add an NFData instance to CountryCode

### DIFF
--- a/country-codes.cabal
+++ b/country-codes.cabal
@@ -30,6 +30,7 @@ library
       base                 >= 4    && < 5
     , text                 >= 0.11
     , aeson                >= 0.5
+    , deepseq              >= 1.4
     , shakespeare          == 2.0.*
   ghc-options:      -Wall
   other-modules:    Data.CountryCodes.ISO31661

--- a/src/Data/CountryCodes/ISO31661.hs
+++ b/src/Data/CountryCodes/ISO31661.hs
@@ -13,10 +13,11 @@ module Data.CountryCodes.ISO31661 (
 ) where
 
 import Control.Applicative (pure)
+import Control.DeepSeq (NFData(..))
 import           Data.Aeson
 import           Data.Typeable
 import qualified Data.Text as T
-import           Prelude (Show,Read,Eq,Ord,Bounded,Enum,error,($),(++),Maybe(..),(.),fail)
+import           Prelude (Show,Read,Eq,Ord,Bounded,Enum,error,($),(++),Maybe(..),(.),fail,seq)
 import           Text.Shakespeare.I18N
 
 data CountryCode = 
@@ -1560,3 +1561,6 @@ instance FromJSON CountryCode where
 instance RenderMessage master CountryCode where
   renderMessage _ _ = toName
 
+-- | Allow the deep evaluation of CountryCode with `deepseq`
+instance NFData CountryCode where
+  rnf a = a `seq` ()


### PR DESCRIPTION
We encountered a use case for `deepseq`, but it requires every part of a data structure to implement `NFData`.

Implementing `NFData` as needed results in a warning about orphan instances, which is undesirable. Instead, it would be nice if the `country-codes` package provided the `NFData` instance.
